### PR TITLE
Bug fix to avoid conflicts when running display in Oviedo

### DIFF
--- a/display/core/DisplayClass.cc
+++ b/display/core/DisplayClass.cc
@@ -1,10 +1,10 @@
-#include "display/core/Display.hh"
+#include "display/core/DisplayClass.hh"
 
 #include "tools/src/HistoUtils.hh"
 
-ClassImp(Display)
+ClassImp(DisplayClass)
 
-Display::Display():
+DisplayClass::DisplayClass():
 _c(0),_leg(0),_empty(0),_hMC(0),_hData(0),_gData(0)
 {
  
@@ -41,12 +41,12 @@ _c(0),_leg(0),_empty(0),_hMC(0),_hData(0),_gData(0)
 
 }
 
-Display::~Display() {
+DisplayClass::~DisplayClass() {
 
 }
 
 void
-Display::reset() {
+DisplayClass::reset() {
   _gWeights.clear();
   _colors.clear();
   _names.clear();
@@ -116,7 +116,7 @@ Display::reset() {
 }
 
 void
-Display::softReset() {
+DisplayClass::softReset() {
   delete _empty;
   delete _hMC;
   delete _hData;
@@ -162,7 +162,7 @@ Display::softReset() {
 }
 
 void
-Display::refreshHistos() {
+DisplayClass::refreshHistos() {
  
   for(size_t ii=0;ii<_hClones.size();ii++)
     delete _hClones[ii];
@@ -187,12 +187,12 @@ Display::refreshHistos() {
 }
 
 void
-Display::setFitStr(string str) {
+DisplayClass::setFitStr(string str) {
   _fitStr=str;
 }
 
 void 
-Display::setNormalization(string str) {
+DisplayClass::setNormalization(string str) {
 
   size_t b=(size_t)-1;
   
@@ -217,7 +217,7 @@ Display::setNormalization(string str) {
 }
 
 void
-Display::loadAutoBinning(string filename) {
+DisplayClass::loadAutoBinning(string filename) {
 
   if(filename=="") return;
 
@@ -257,7 +257,7 @@ Display::loadAutoBinning(string filename) {
 }
 
 void 
-Display::setObservables(string v1, string v2, string v3,
+DisplayClass::setObservables(string v1, string v2, string v3,
 			string v4, string v5, string v6) {
 
   _vars.push_back(v1);
@@ -272,12 +272,12 @@ Display::setObservables(string v1, string v2, string v3,
 }
 
 // void
-// Display::getSystUnc( TGraphAsymmErrors* mcUnc) {
+// DisplayClass::getSystUnc( TGraphAsymmErrors* mcUnc) {
 //   _mcUncert = mcUnc;
 // }
 
 vector<vector<TPad*> > 
-Display::preparePads() {
+DisplayClass::preparePads() {
   
   //  float m=1.3;
 
@@ -339,7 +339,7 @@ Display::preparePads() {
 
 
 vector<vector<TPad*> > 
-Display::preparePadsWithRatio() {
+DisplayClass::preparePadsWithRatio() {
 
 
   float m=1.3;
@@ -434,7 +434,7 @@ Display::preparePadsWithRatio() {
 
 
 void
-Display::preparePadsForSystDetail() {
+DisplayClass::preparePadsForSystDetail() {
   
   _cSyst = new TCanvas("systematics", "systematics",1250,380);
   _cSyst->Range(0,0,1,1);
@@ -480,7 +480,7 @@ Display::preparePadsForSystDetail() {
 
 
 void 
-Display::plotDistributions(vector<const hObs*> theObs) {
+DisplayClass::plotDistributions(vector<const hObs*> theObs) {
 
   //first clean objects
   for(size_t ix=0;ix<_pads.size();ix++)
@@ -529,7 +529,7 @@ Display::plotDistributions(vector<const hObs*> theObs) {
 
 
 void
-Display::plotDistribution(const string& htype, const string& type,
+DisplayClass::plotDistribution(const string& htype, const string& type,
 			  int iobs) {
 
   _c->cd();
@@ -585,7 +585,7 @@ Display::plotDistribution(const string& htype, const string& type,
 
 
 void
-Display::configure(string dsname, int col, bool isGhost) {
+DisplayClass::configure(string dsname, int col, bool isGhost) {
   // if(dsname.find("DD")!=(size_t)-1)
   //   _names.push_back( dsname.substr(0,dsname.size()-2) );
   // else
@@ -603,20 +603,20 @@ Display::configure(string dsname, int col, bool isGhost) {
 }
 
 void
-Display::setWeight(string dsname, float w) {
+DisplayClass::setWeight(string dsname, float w) {
   _gWeights[ dsname ] = w;
   _saveWeights[ dsname ] = w;
 }
 
 string
-Display::getFitVar() {
+DisplayClass::getFitVar() {
   size_t p=_fitStr.find("::");
   string nvar=_fitStr.substr(0,p);
   return nvar;
 }
 
 void
-Display::initWeights(const hObs* theobs) {
+DisplayClass::initWeights(const hObs* theobs) {
 
   if(_normOpts.find("fit")!=_normOpts.end() ) {
     prepareHistograms(theobs);
@@ -636,7 +636,7 @@ Display::initWeights(const hObs* theobs) {
 }
 
 void
-Display::drawDistribution() {
+DisplayClass::drawDistribution() {
 
   //Drawing now.... (+legend) ============================
   if(_is1D)
@@ -752,7 +752,7 @@ Display::drawDistribution() {
 
 
 void
-Display::changeGeVToTeV(TH1*& h,string xtitle, string ytitle, float xmin, float xmax, float ymin, float ymax, string hType, bool& xAxTeV, bool& yAxTeV) {
+DisplayClass::changeGeVToTeV(TH1*& h,string xtitle, string ytitle, float xmin, float xmax, float ymin, float ymax, string hType, bool& xAxTeV, bool& yAxTeV) {
 
   bool isXTitle=xtitle.find("GeV")!=(size_t)-1;
   bool isYTitle=ytitle.find("GeV")!=(size_t)-1;
@@ -833,7 +833,7 @@ Display::changeGeVToTeV(TH1*& h,string xtitle, string ytitle, float xmin, float 
 }
   
 void
-Display::prepareHistograms(const hObs* theobs) {
+DisplayClass::prepareHistograms(const hObs* theobs) {
 
   // //bypass for ghost datasets =====
   // for(size_t ih=0;ih<_nhmc;ih++) {
@@ -999,7 +999,7 @@ Display::prepareHistograms(const hObs* theobs) {
 
   //FIXME MM
   // for(size_t ih=0;ih<_nhmc;ih++) {
-  //   cout<<" fixme, line 960 Display.cc "<<endl;
+  //   cout<<" fixme, line 960 DisplayClass.cc "<<endl;
   //   HistoUtils::manualCompleteRebin(_hClones[ih], 15,0,15);
   //   HistoUtils::manualCompleteRebin(_hClonesNoStack[ih],15,0,15);
   // }
@@ -1353,7 +1353,7 @@ Display::prepareHistograms(const hObs* theobs) {
 }
 
 void 
-Display::saveDMCRWeight(string fname, string hname) {
+DisplayClass::saveDMCRWeight(string fname, string hname) {
 
   TFile* file=new TFile(fname.c_str(),"RECREATE");
 
@@ -1370,7 +1370,7 @@ Display::saveDMCRWeight(string fname, string hname) {
 }
 
 void 
-Display::drawDataMCRatio() {
+DisplayClass::drawDataMCRatio() {
   
   //The bidon histo
   TH1* emptyHisto=(TH1*)_hMC->Clone();
@@ -1521,7 +1521,7 @@ Display::drawDataMCRatio() {
 }
 
 void
-Display::ratioObservables(vector<const hObs*> theObs) {
+DisplayClass::ratioObservables(vector<const hObs*> theObs) {
 
   softReset();
   
@@ -1644,7 +1644,7 @@ Display::ratioObservables(vector<const hObs*> theObs) {
 }
 
 void
-Display::saveHistos(string o1, const hObs* theObs) {
+DisplayClass::saveHistos(string o1, const hObs* theObs) {
   
   TFile* oFile=new TFile((o1+".root").c_str(), "RECREATE");
   for(size_t ih=0;ih<_nhmc;ih++) {
@@ -1660,7 +1660,7 @@ Display::saveHistos(string o1, const hObs* theObs) {
 }
 
 void
-Display::showSignificance(const hObs* theObs) {
+DisplayClass::showSignificance(const hObs* theObs) {
   
   softReset();
 
@@ -1716,7 +1716,7 @@ Display::showSignificance(const hObs* theObs) {
 }
 
 void
-Display::drawEfficiency(const hObs* theObs) {
+DisplayClass::drawEfficiency(const hObs* theObs) {
 
 
   softReset();
@@ -1777,7 +1777,7 @@ Display::drawEfficiency(const hObs* theObs) {
 }
 
 void
-Display::drawROCCurves(const hObs* theObs) {
+DisplayClass::drawROCCurves(const hObs* theObs) {
 
   softReset();
   
@@ -1828,7 +1828,7 @@ Display::drawROCCurves(const hObs* theObs) {
 
 
 void
-Display::compaROCCurves(vector<const hObs*> obss) {
+DisplayClass::compaROCCurves(vector<const hObs*> obss) {
   
   softReset();
   
@@ -1894,7 +1894,7 @@ Display::compaROCCurves(vector<const hObs*> obss) {
 
 
 void
-Display::residualData(const hObs* theObs) {
+DisplayClass::residualData(const hObs* theObs) {
 
   softReset();
   
@@ -1986,7 +1986,7 @@ Display::residualData(const hObs* theObs) {
 }
 
 void
-Display::drawCumulativeHistos(const hObs* theObs ) {
+DisplayClass::drawCumulativeHistos(const hObs* theObs ) {
  
   softReset();
   _cumulative =true;
@@ -1999,7 +1999,7 @@ Display::drawCumulativeHistos(const hObs* theObs ) {
 }
 
 void
-Display::drawStatistics(vector<pair<string,vector<vector<float> > > > vals, 
+DisplayClass::drawStatistics(vector<pair<string,vector<vector<float> > > > vals, 
 			vector<string> dsnames) {
   _comSyst = false;
   softReset();
@@ -2031,7 +2031,7 @@ Display::drawStatistics(vector<pair<string,vector<vector<float> > > > vals,
 }
 
 void
-Display::prepareStatistics( vector<pair<string,vector<vector<float> > > > vals, 
+DisplayClass::prepareStatistics( vector<pair<string,vector<vector<float> > > > vals, 
 			    vector<string> dsnames) {
 
 
@@ -2167,15 +2167,15 @@ Display::prepareStatistics( vector<pair<string,vector<vector<float> > > > vals,
 }
 
 void
-Display::configureDisplay(string YTitle, double rangeY[2], 
-			  double rangeX[2], bool logYscale,
-			  int Xdiv[3], int Ydiv[3], 
-			  int gbin, int bckbin, 
-			  bool OverFlowBin, bool UnderFlowBin,
-			  bool ShowDMCRatio, bool ShowGrid, bool staking,
-			  bool AddSystematics, bool mcStatSyst,
-			  float MarkerSize, float LineWidth, bool sSignal,
-			  bool mcOnly, bool cmsPrel, bool uncDet ) {
+DisplayClass::configureDisplay(string YTitle, double rangeY[2], 
+			       double rangeX[2], bool logYscale,
+			       int Xdiv[3], int Ydiv[3], 
+			       int gbin, int bckbin, 
+			       bool OverFlowBin, bool UnderFlowBin,
+			       bool ShowDMCRatio, bool ShowGrid, bool staking,
+			       bool AddSystematics, bool mcStatSyst,
+			       float MarkerSize, float LineWidth, bool sSignal,
+			       bool mcOnly, bool cmsPrel, bool uncDet ) {
 
   _ytitle = YTitle;
   _ymin = rangeY[0];
@@ -2221,13 +2221,13 @@ Display::configureDisplay(string YTitle, double rangeY[2],
 
 
 void
-Display::checkData() {
+DisplayClass::checkData() {
   if(_mcOnly) _mcOnly=false;
   _lockData=true;
 }
 
 void
-Display::isNoData() {
+DisplayClass::isNoData() {
   if(!_lockData)
     if(!_mcOnly) _mcOnly=true;
 
@@ -2237,7 +2237,7 @@ Display::isNoData() {
 
 
 void
-Display::computeSystematics(bool isProf, bool cumul) {
+DisplayClass::computeSystematics(bool isProf, bool cumul) {
 
   for(size_t ii=0;ii<_mcUncert.size();ii++)
     delete _mcUncert[ii];
@@ -2457,13 +2457,13 @@ Display::computeSystematics(bool isProf, bool cumul) {
 }
 
 void
-Display::setSystematicsUnc( vector<vector<systM> > systs ) {
+DisplayClass::setSystematicsUnc( vector<vector<systM> > systs ) {
   _systMUnc = systs;
 }
 
 
 void
-Display::drawDetailSystematics(bool cumul) {
+DisplayClass::drawDetailSystematics(bool cumul) {
   //turn on detail
   _uncDet=true;
   _csystM = _systMUnc[0];
@@ -2652,13 +2652,13 @@ Display::drawDetailSystematics(bool cumul) {
 
 
 void
-Display::getIntegral(float x1, float x2, float y1, float y2) {
+DisplayClass::getIntegral(float x1, float x2, float y1, float y2) {
   printInteg(x1,x2,y1,y2);
 }
 
 
 void
-Display::printInteg(float x1, float x2, float y1, float y2) {
+DisplayClass::printInteg(float x1, float x2, float y1, float y2) {
 
   vector<double> errors(_nhmc+2,0);
   
@@ -2752,7 +2752,7 @@ Display::printInteg(float x1, float x2, float y1, float y2) {
 //new CMS preliminary (thanks gautier..)
 
 void 
-Display::cmsPrel() {
+DisplayClass::cmsPrel() {
   TLatex latex;
   
   float t = _pads[0][0]->GetTopMargin();
@@ -2825,7 +2825,7 @@ Display::cmsPrel() {
 
 
 void
-Display::addText(float x, float y, float s, string text) {
+DisplayClass::addText(float x, float y, float s, string text) {
   _pads[0][0]->cd();
 
   TLatex t;
@@ -2838,7 +2838,7 @@ Display::addText(float x, float y, float s, string text) {
 
 
 void
-Display::addLine(float x1, float y1, float x2, float y2, int style, int col, int size) {
+DisplayClass::addLine(float x1, float y1, float x2, float y2, int style, int col, int size) {
   _pads[0][0]->cd();
 
   TLine* l=new TLine(x1,y1,x2,y2);
@@ -2850,7 +2850,7 @@ Display::addLine(float x1, float y1, float x2, float y2, int style, int col, int
 }
 
 void
-Display::adjustLegend(int iobs, bool skipCoords) {
+DisplayClass::adjustLegend(int iobs, bool skipCoords) {
   float xd,xu,yd,yu,f=1.;
   
   if(!skipCoords) {
@@ -2935,7 +2935,7 @@ Display::adjustLegend(int iobs, bool skipCoords) {
 }
 
 void
-Display::getLegendCoordinate(TH1*h, float& pxd, float& pyd, float& pxu, float& pyu,float& fo, int iobs) {
+DisplayClass::getLegendCoordinate(TH1*h, float& pxd, float& pyd, float& pxu, float& pyu,float& fo, int iobs) {
 
   //default values
   pxd = 0.5;
@@ -3048,7 +3048,7 @@ Display::getLegendCoordinate(TH1*h, float& pxd, float& pyd, float& pxu, float& p
 
 
 float
-Display::graphVal(float x,int ih, int iobs) {
+DisplayClass::graphVal(float x,int ih, int iobs) {
   
   float X = _pads[0][iobs]->PixeltoX( x*_wpad  );
   size_t bin = StatUtils::findBin<float>(X, _hCoords[ih][0] );
@@ -3062,7 +3062,7 @@ Display::graphVal(float x,int ih, int iobs) {
 }
 
 void
-Display::graphConstraint(size_t ih, int iobs, float& xd, float& xu, float& yd, float& yu,float& f, float dx, float dy) {
+DisplayClass::graphConstraint(size_t ih, int iobs, float& xd, float& xu, float& yd, float& yu,float& f, float dx, float dy) {
 
   bool lCorIP= (yd < graphVal(xd,ih,iobs));
   bool rCorIP= (yd < graphVal(xu,ih,iobs));

--- a/display/core/DisplayClass.hh
+++ b/display/core/DisplayClass.hh
@@ -42,7 +42,7 @@
 
 using namespace std;
 
-class Display {
+class DisplayClass {
 
 private:
 
@@ -180,8 +180,8 @@ private:
 
 public:
 
-  Display();
-  virtual ~Display();
+  DisplayClass();
+  virtual ~DisplayClass();
 
   void reset();
   void softReset();
@@ -302,7 +302,7 @@ private:
   void graphConstraint(size_t ih, int iobs, float& xd, float& xu, float& yd,
 		       float& yu,float& f, float dx, float dy);
 
-  ClassDef(Display,0)  
+  ClassDef(DisplayClass,0)  
 
 };
 

--- a/display/core/LinkDef.h
+++ b/display/core/LinkDef.h
@@ -5,7 +5,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class AnaConfig+;
-#pragma link C++ class Display+;
+#pragma link C++ class DisplayClass+;
 #pragma link C++ class MPAFDisplay+;
 #pragma link C++ class Renorm+;
 

--- a/display/core/MPAFDisplay.cc
+++ b/display/core/MPAFDisplay.cc
@@ -72,7 +72,7 @@ MPAFDisplay::getStatistics(string categ) {
 void 
 MPAFDisplay::setNumbers() {
   if(!_recompute) return;
-
+  
   for(size_t id=0;id<_dsNames.size();id++) {
     _au->addDataset(_dsNames[id]);
   }
@@ -83,7 +83,7 @@ MPAFDisplay::setNumbers() {
   size_t bh = 0;
   
   int icat=1; //0 for global
-
+  
   for(int i=(int)(statFiles.size())-1; i>=0; i--) {
     
     if(statFiles.size()>1 && i!=0)
@@ -93,7 +93,7 @@ MPAFDisplay::setNumbers() {
 
     if(ctag.size()>4 && ctag.substr(ctag.size()-4) == ".dat")
       ctag.erase(ctag.size()-4,4);
-      
+    
     readStatFile( statFiles[i], ctag, icat);
   }
 
@@ -110,7 +110,7 @@ MPAFDisplay::readStatFile(string filename, string ctag, int& icat) {
   ifstream fDb( ndb.c_str(), ios::in );
 
   map<pair<string,string>, bool > fVal;
-
+  
   if(fDb)  {
     string line;
     
@@ -168,12 +168,12 @@ MPAFDisplay::readStatFile(string filename, string ctag, int& icat) {
       else if(tks[0]=="selection") continue;
  
       else {
- 
+	
         size_t n=tks.size()-4;
         cname="";
         for(size_t i=0;i<n;i++)
           cname += tks[i]+" ";
-          
+	
         sname = tks[n];
 	
         Dataset* ds=anConf.findDS( sname );
@@ -230,9 +230,9 @@ MPAFDisplay::readStatFile(string filename, string ctag, int& icat) {
 void
 MPAFDisplay::prepareDisplay(){
 
-  configure();
-  dp.setLumi( anConf.getLumi() );
-  setNumbers();
+  cout << "configure" << endl;  configure();
+  cout << "setLumi" << endl; dp.setLumi( anConf.getLumi() );
+  cout << "setNumbers" << endl; setNumbers();
 
 }
 

--- a/display/core/MPAFDisplay.hh
+++ b/display/core/MPAFDisplay.hh
@@ -12,7 +12,7 @@
 
 
 #include "display/core/AnaConfig.hh"
-#include "display/core/Display.hh"
+#include "display/core/DisplayClass.hh"
 #include "tools/src/AnaUtils.hh"
 #include "tools/src/Dataset.hh"
 #include "tools/src/DataBaseManager.hh"
@@ -53,7 +53,7 @@ public:
 
   AnaConfig anConf;
 
-  Display dp;
+  DisplayClass dp;
 
   //===== functions ====
 

--- a/display/core/module.mk
+++ b/display/core/module.mk
@@ -1,6 +1,6 @@
 #Source files to compile
 FILES += AnaConfig
-FILES += Display
+FILES += DisplayClass
 FILES += MPAFDisplay
 FILES += Renorm
 


### PR DESCRIPTION
It should be transparent for everybody else, it basically renames Display.hh to DisplayClass.hh and all the relevant calls to it 