### PR TITLE
Update of skimming and weighting

### DIFF
--- a/analysis/core/MPAF.cc
+++ b/analysis/core/MPAF.cc
@@ -13,7 +13,7 @@
 #include "analysis/core/MPAF.hh"
 
 
-
+#include <TObjArray.h>
 
 /*****************************************************************************
 ******************************************************************************
@@ -130,14 +130,14 @@ void MPAF::analyze(){
     }
 	
     // loop over entries
-    unsigned int nEvts = _datasets[i]->getNEvents();
-    if(_nEvtMax!=(size_t)-1) nEvts =  min(_nEvtMax+_nSkip,nEvts);
-
+    _nEvts[i] = _datasets[i]->getNEvents();
+    _nEvtsDs[i] = _nEvts[i];
+    if(_nEvtMax!=(size_t)-1) _nEvts[i] =  min(_nEvtMax+_nSkip,_nEvts[i]);
     
-    cout<<" Starting processing dataset : "<<_sampleName<<"  (running on "<<nEvts<<" events)"<<endl;
+    cout<<" Starting processing dataset : "<<_sampleName<<"  (running on "<<_nEvts[i]<<" events)"<<endl;
 
-    boost::progress_display show_progress( nEvts );
-    for(_ie = _nSkip; _ie < nEvts; ++_ie) {
+    boost::progress_display show_progress( _nEvts[i] );
+    for(_ie = _nSkip; _ie < _nEvts[i]; ++_ie) {
       ++show_progress;
       stw.Start();
       
@@ -303,6 +303,8 @@ void MPAF::loadConfigurationFile(std::string cfg){
     dsName+=pfx;
 
     _datasets.push_back(new Dataset(dsName));
+    _nEvtsDs.push_back(0);
+    _nEvts.push_back(0);
     
     SampleId sId;
     sId.name = it->second.val; //was val
@@ -411,8 +413,9 @@ void MPAF::internalWriteOutput() {
   map<string, int> cnts;
   map<string, double> wgtcnts;
   for(unsigned int ids=0;ids<_datasets.size(); ++ids) {
-    cnts[ _datasets[ids]->getName() ] = _datasets[ids]->getNProcEvents();
-    wgtcnts[ _datasets[ids]->getName() ] = _datasets[ids]->getSumProcWgts();
+    float fact=(float)_nEvts[ids]/_nEvtsDs[ids];
+    cnts[ _datasets[ids]->getName() ] = _datasets[ids]->getNProcEvents() * fact;
+    wgtcnts[ _datasets[ids]->getName() ] = _datasets[ids]->getSumProcWgts() * fact;
   }
 
   cout << "writing output to disk" << endl;
@@ -667,8 +670,14 @@ void MPAF::initSkimming() {
   _datasets[_inds]->getTree()->LoadTree(0);
   if(_fullSkim) {
     _skimTree = (TTree*)_datasets[_inds]->getTree()->CloneTree(0);
+    //for friend tree merging
+    _vc->linkFriendBranches(_skimTree);
+
     _hnSkim =new TH1I( _hname.c_str(), _hname.c_str(), 1, 0, 1);
     _hnSkim->SetBinContent(1,_datasets[_inds]->getNProcEvents() );
+
+    _hnwSkim =new TH1D( _hwgtname.c_str(), _hwgtname.c_str(), 1, 0, 1);
+    _hnwSkim->SetBinContent(1,_datasets[_inds]->getSumProcWgts() );
   }
   else {
     TString name = _datasets[_inds]->getTree()->GetName();
@@ -686,6 +695,8 @@ void MPAF::finalizeSkimming() {
   _skimTree->Write();
   if(_hnSkim)
     _hnSkim->Write();
+  if(_hnwSkim)
+    _hnwSkim->Write();
   _oFile->Write();
   _oFile->Close();
 }

--- a/analysis/core/MPAF.hh
+++ b/analysis/core/MPAF.hh
@@ -191,6 +191,8 @@ private:
    
   int _inds;
 
+  vector<unsigned int> _nEvtsDs;
+  vector<unsigned int> _nEvts; 
   unsigned int _nEvtMax; 
   unsigned int _nSkip; 
   bool _summary;
@@ -201,7 +203,7 @@ private:
   TFile* _oFile;
   TTree* _skimTree;
   TH1I* _hnSkim;
-
+  TH1D* _hnwSkim;
 
 
   bool _skim;

--- a/analysis/core/VarClass.hh
+++ b/analysis/core/VarClass.hh
@@ -320,6 +320,8 @@ public:
   // void applyWSystVar(string name, int dir, float& w, vector<string> vars, 
   // 		     string db, string type);
 	
+  void linkFriendBranches(TTree*& tree);
+
   void nextEvent(){ _nextEvent=true;};
   void sameEvent(){ _nextEvent=false;};
 	
@@ -343,6 +345,12 @@ private:
   double findAVal(int tType, int key, int idx);
 
   vector<float> getUnivF(int id);
+
+
+  void linkBranch(string name);
+  void linkScalarVal(string name, int tType, int key);
+  void linkVectorVal(string name, int tType, int key);
+  void linkArrayVal(string name, int tType, int key);
 
   // Public Members
 
@@ -463,7 +471,8 @@ private:
   mapD uncmD;
   mapF uncmF;
 	
-
+  TTree* _mTree;
+  vector<string> _friendBranches;
 
   bool _nextEvent;
 	


### PR DESCRIPTION
- when trees are skimmed, now copy as well the variables contained in the friend trees
- when a maximum number of event is set, the counter histograms are scaled accordlingly to the ratio of the number of event processed and the total number of events
- the SumGenWeight histogram is now correctly copied when a skimming is done