### PR TITLE
Centralize LHE weights to SSDL2015 and SUSY3L

### DIFF
--- a/analysis/modules/SusyModule.cc
+++ b/analysis/modules/SusyModule.cc
@@ -803,6 +803,22 @@ SusyModule::correctFlipRate(float& rate, float eta){
 
 }
 
+//LHE weights
+double
+SusyModule::getLHEweight(int LHEsysID){
+
+  int tmp_nlhe=_vc->get("nLHEweight");
+  for (int i=0; i<tmp_nlhe; i++) {
+    int tmp_lhe_id = _vc->get("LHEweight_id", i);
+    if (tmp_lhe_id == LHEsysID) {
+      double tmp_lhe_wgt = _vc->get("LHEweight_wgt", i);
+      return tmp_lhe_wgt;
+    } 
+  }
+  return 1.0;
+
+}
+
 
 // Scale factors ====================================
 void

--- a/analysis/modules/SusyModule.hh
+++ b/analysis/modules/SusyModule.hh
@@ -94,6 +94,7 @@ public:
 
   void correctFlipRate(float& rate, float eta);
 
+  double getLHEweight(int LHEsysID);
   void applyHLTSF(const string& hltLine, float& weight);
   void applyHLTSF(const string& hltLine, const vector<Candidate*>& cands, float& weight);
   void applyLepSF(const CandList& cands, float& weight);

--- a/analysis/src/SSDL2015.cc
+++ b/analysis/src/SSDL2015.cc
@@ -263,7 +263,7 @@ SSDL2015::initialize(){
   _leppt   = getCfgVarS("LEPPT"  , "all");
   _SR      = getCfgVarS("SR"     , "BR02H");
   _FR      = getCfgVarS("FR"     , "FO2C");
-  _LHESYS = getCfgVarS("LHESYS", "");
+  _LHESYS = getCfgVarI("LHESYS", 0);
   _categorization = getCfgVarI("categorization", 1);
   _mergeSRs = getCfgVarI("mergeSRs",0);
   _DoValidationPlots = getCfgVarI("ValidationPlots", 0);
@@ -334,14 +334,6 @@ SSDL2015::initialize(){
   _dbm->loadDb("FastSimElSF", "sf_el_tight_IDEmu_ISOEMu_ra5.root", "histo3D");
   _dbm->loadDb("FastSimMuSF", "sf_mu_mediumID_multi.root"        , "histo3D");
 
- 
-  int ilhe = (int)atoi(_LHESYS.c_str());
-  bool tmp_ismux = ilhe >= 1001 && ilhe <= 1009;
-  bool tmp_ispdf = ilhe >= 2001 && ilhe <= 2100;
-  
-  if (!tmp_ismux && !tmp_ispdf) {
-    _LHESYS = "0";
-  }
 
 }
 
@@ -350,28 +342,14 @@ SSDL2015::modifyWeight() {
 
   if (_vc->get("isData") != 1) {
     //generator weights
-    if (_LHESYS == "0") {_weight *= _vc->get("genWeight");}
-    else {_weight *= lheWeight();}
+    if (_LHESYS == 0) {_weight *= _vc->get("genWeight");}
+    else {_weight *= _susyMod->getLHEweight(_LHESYS);}
     //pileup weights
     _weight *= _vc->get("vtxWeight");
   }
 
 }
 
-double        
-SSDL2015::lheWeight() {
-
-  int tmp_nlhe=_vc->get("nLHEweight");
-  for (int i=0; i<tmp_nlhe; i++) {
-    int tmp_lhe_id = _vc->get("LHEweight_id", i);
-    if (tmp_lhe_id == (int)atoi(_LHESYS.c_str())) {
-      double tmp_lhe_wgt = _vc->get("LHEweight_wgt", i);
-      return tmp_lhe_wgt;
-    } 
-  }
-  return 1.0;
-
-}
 
 void
 SSDL2015::modifySkimming() {

--- a/analysis/src/SSDL2015.hh
+++ b/analysis/src/SSDL2015.hh
@@ -22,7 +22,6 @@ private:
   void run();
   void defineOutput();
   void modifyWeight();
-  double lheWeight();
   void writeOutput();
 
   void modifySkimming();
@@ -279,7 +278,7 @@ private:
   string _leptl;
   string _SR;
   string _FR;
-  string _LHESYS;
+  int _LHESYS;
 
   int _fakeEl;
   int _fakeMu;

--- a/analysis/src/SUSY3L.cc
+++ b/analysis/src/SUSY3L.cc
@@ -147,6 +147,11 @@ void SUSY3L::initialize(){
     _vc->registerVar("HLT_DoubleMuHT"                  );
     _vc->registerVar("HLT_DoubleElHT"                  );
     
+    //LHE gen level weights                                                                                                                                                       
+    _vc->registerVar("nLHEweight"                   );
+    _vc->registerVar("LHEweight_id"                 );
+    _vc->registerVar("LHEweight_wgt"                );
+
     _vc->registerVar("genWeight"                       );       //generator weight to account for negative weights in MCatNLO
     _vc->registerVar("vtxWeight"                       );       //number of vertices for pile-up reweighting 
 
@@ -167,6 +172,7 @@ void SUSY3L::initialize(){
     _selectTaus = getCfgVarS("selectTaus", "false");
     _BR = getCfgVarS("baselineRegion", "BR0");
     _SR = getCfgVarS("signalRegion", "SR999");
+    _LHESYS = getCfgVarI("LHESYS", 0);
 
     //workflows
     addWorkflow( kWZCR, "WZCR");
@@ -186,7 +192,10 @@ void SUSY3L::modifyWeight() {
     */ 
     
     if (_vc->get("isData") != 1){
-        _weight *= _vc->get("genWeight");
+        //generator weights                                                                                                                                                        
+        if (_LHESYS == 0) {_weight *= _vc->get("genWeight");}
+        else {_weight *= _susyMod->getLHEweight(_LHESYS);}
+        //pileup weights                                                                                                                                                           
         _weight *= _vc->get("vtxWeight");
     }
 

--- a/analysis/src/SUSY3L.hh
+++ b/analysis/src/SUSY3L.hh
@@ -69,6 +69,7 @@ private:
     string _pairmass;
     string _BR;
     string _SR;
+    int _LHESYS;
     
 
 


### PR DESCRIPTION
Centralised the way the LHE weights are implemented for performing studies of theoretical systematics. I checked that I obtain the same results as before for SSDL2015, and now the same machinery is available for SUSY3L.

I googled the issue of the ctrlˆM at the end of lines and implemented some recipe to fix it. Hopefully they do not show up this time (let me know otherwise) 